### PR TITLE
add working cookieconsent2 version because cc2:3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-		"bower-asset/cookieconsent2": "*"
+        "bower-asset/cookieconsent2": "2.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since cookieconsent2 v3.0 this extension not working anymore because the wildcard in composer.json.
Now i fixed it, please tag it as 1.4.4.

thanks