### PR TITLE
Bower asset version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Yii2 Cookie Consent
 ===================
 
 Yii2 Cookie Consent to alerting users about the use of cookies on your Yii2 website, 
-using Cookie Consent Script: https://github.com/silktide/cookieconsent2
+using Cookie Consent Script: https://github.com/insites/cookieconsent/tree/2.0.0
 
 Installation Using Composer
 -----------------
@@ -50,6 +50,7 @@ Changelog
 -----------------
 
 <ul>
+  <li>Version 1.4.6 - Fix Bower Asset version</li>
   <li>Version 1.4.5 - Fix #4 Bower Asset version</li>
   <li>Version 1.4.4 - Update Bower Asset</li>
   <li>Version 1.4.3 - Fix #2 403 forbidden css</li>

--- a/assets/CookieAsset.php
+++ b/assets/CookieAsset.php
@@ -19,7 +19,7 @@ class CookieAsset extends AssetBundle
 	/**
      * @inherit
      */
-	public $sourcePath = '@bower/cookieconsent2/build/';
+	public $sourcePath = '@bower/cookieconsent/build/';
 	
 	/**
      * @inherit

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "yiisoft/yii2": "2.0.*",
-        "bower-asset/cookieconsent2": "2.0.*"
+        "bower-asset/cookieconsent": "2.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Due to changes in the Cookie Consent repo, it was (again) necessary to update bower assets to fix to version 2.0.0.